### PR TITLE
Remove use of webdriver-manager

### DIFF
--- a/ext/requirements-dev.txt
+++ b/ext/requirements-dev.txt
@@ -2,5 +2,4 @@ pillow ~= 9.5.0
 requests ~= 2.30.0
 coverage >= 6.3.1
 codecov >= 2.1.12
-webdriver_manager ~= 3.8.6
 selenium ~= 4.9.1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from amazoncaptcha import AmazonCaptcha, AmazonCaptchaCollector, ContentTypeError, NotFolderError, __version__
-from webdriver_manager.chrome import ChromeDriverManager
 from selenium import webdriver
 import unittest
 import sys
@@ -67,7 +66,7 @@ class TestAmazonCaptcha(unittest.TestCase):
         options = webdriver.ChromeOptions()
         options.add_argument('no-sandbox')
         options.add_argument('headless')
-        driver = webdriver.Chrome(ChromeDriverManager().install(), options=options)
+        driver = webdriver.Chrome(options=options)
 
         solutions = list()
         for i in range(5):


### PR DESCRIPTION
This commit removes the use of the webdriver-manager package. Apparently, since selenium v4.6 this package is not necessary and selenium handles webdriver management using its own [selenium-manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/) facility.

In testing, this resolves the errors produced when bumping the Pillow version to 10.1.0.